### PR TITLE
[HOPSWORKS-1425] fix hopsworks to work with hopsfs scheme"

### DIFF
--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/dataset/util/DatasetPath.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/dataset/util/DatasetPath.java
@@ -19,13 +19,12 @@ import io.hops.hopsworks.common.dao.dataset.Dataset;
 import io.hops.hopsworks.common.dao.dataset.DatasetSharedWith;
 import io.hops.hopsworks.common.dao.hdfs.inode.Inode;
 import io.hops.hopsworks.common.dao.project.Project;
+import io.hops.hopsworks.common.hdfs.Utils;
 import io.hops.hopsworks.common.util.Settings;
 import org.apache.hadoop.fs.Path;
 
 import java.io.File;
 import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 public class DatasetPath {
@@ -38,7 +37,7 @@ public class DatasetPath {
   private Inode inode;
   
   public DatasetPath(Project project, String path, String root) throws UnsupportedEncodingException {
-    String p = prepPath(path);
+    String p = Utils.prepPath(path);
     String pathStr = stripSlash(p);
     String pathRoot = stripSlash(root); // Projects or /apps/hive/warehouse
     boolean isProject = root.equals(Settings.DIR_ROOT);
@@ -145,24 +144,6 @@ public class DatasetPath {
     String[] parts = fullPath.split(File.separator);
     String dsPath = String.join(File.separator, Arrays.copyOfRange(parts, 0, root.depth() + 1));
     return new Path(File.separator + dsPath);
-  }
-  
-  private String prepPath(String path) throws UnsupportedEncodingException {
-    Path p;
-    String result = path;
-    if (path.contains(Settings.SHARED_FILE_SEPARATOR)) {
-      String[] parts = path.split(Settings.SHARED_FILE_SEPARATOR);
-      p = new Path(parts[0]);
-      //remove hdfs://10.0.2.15:8020//
-      p = new Path(URLDecoder.decode(p.toUri().getRawPath(), StandardCharsets.UTF_8.toString()));
-      result = p.toString() + Settings.SHARED_FILE_SEPARATOR + parts[1];
-    } else {
-      p = new Path(path);
-      //remove hdfs://10.0.2.15:8020//
-      p = new Path(URLDecoder.decode(p.toUri().getRawPath(), StandardCharsets.UTF_8.toString()));
-      result = p.toString();
-    }
-    return result;
   }
   
   private String stripSlash(String path) {

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/featurestore/trainingdataset/TrainingDatasetService.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/featurestore/trainingdataset/TrainingDatasetService.java
@@ -49,6 +49,7 @@ import io.hops.hopsworks.restutils.RESTCodes;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import java.io.UnsupportedEncodingException;
 
 import javax.ejb.EJB;
 import javax.ejb.TransactionAttribute;
@@ -162,7 +163,8 @@ public class TrainingDatasetService {
   @ApiOperation(value = "Create training dataset for a featurestore",
       response = TrainingDatasetDTO.class)
   public Response createTrainingDataset(@Context SecurityContext sc, TrainingDatasetDTO trainingDatasetDTO)
-    throws DatasetException, HopsSecurityException, ProjectException, FeaturestoreException {
+    throws DatasetException, HopsSecurityException, ProjectException, FeaturestoreException,
+      UnsupportedEncodingException {
     if(trainingDatasetDTO == null){
       throw new IllegalArgumentException("Input JSON for creating a new Training Dataset cannot be null");
     }
@@ -258,7 +260,7 @@ public class TrainingDatasetService {
   public Response deleteTrainingDataset(
       @Context SecurityContext sc, @ApiParam(value = "Id of the training dataset", required = true)
       @PathParam("trainingdatasetid") Integer trainingdatasetid) throws FeaturestoreException, DatasetException,
-      ProjectException, HopsSecurityException {
+      ProjectException, HopsSecurityException, UnsupportedEncodingException {
     verifyIdProvided(trainingdatasetid);
     Users user = jWTHelper.getUserPrincipal(sc);
     TrainingDatasetDTO trainingDatasetDTO = trainingDatasetController.getTrainingDatasetWithIdAndFeaturestore(
@@ -307,7 +309,8 @@ public class TrainingDatasetService {
     @ApiParam(value = "updateStats", example = "true", defaultValue = "false")
     @QueryParam("updateStats") Boolean updateStats,
     TrainingDatasetDTO trainingDatasetDTO)
-      throws FeaturestoreException, DatasetException, ProjectException, HopsSecurityException {
+      throws FeaturestoreException, DatasetException, ProjectException, HopsSecurityException,
+      UnsupportedEncodingException {
     if(trainingDatasetDTO == null){
       throw new IllegalArgumentException("Input JSON for updating a Training Dataset cannot be null");
     }

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/jobs/executions/ExecutionsResource.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/jobs/executions/ExecutionsResource.java
@@ -37,6 +37,7 @@ import io.hops.hopsworks.jwt.annotation.JWTRequired;
 import io.hops.hopsworks.restutils.RESTCodes;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import java.io.UnsupportedEncodingException;
 
 import javax.ejb.EJB;
 import javax.ejb.TransactionAttribute;
@@ -134,7 +135,8 @@ public class ExecutionsResource {
   public Response execution(
     @ApiParam(value = "start or stop", required = true) @QueryParam("action") Action action,
     @Context SecurityContext sc,
-    @Context UriInfo uriInfo) throws JobException, GenericException, ServiceException, ProjectException {
+    @Context UriInfo uriInfo) throws JobException, GenericException, ServiceException, ProjectException,
+      UnsupportedEncodingException {
     
     Users user = jWTHelper.getUserPrincipal(sc);
     Execution exec;

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/project/ProjectService.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/project/ProjectService.java
@@ -130,6 +130,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -524,7 +525,7 @@ public class ProjectService {
   public Response example(@PathParam("type") String type, @Context HttpServletRequest req, @Context SecurityContext sc)
       throws DatasetException,
       GenericException, KafkaException, ProjectException, UserException, ServiceException, HopsSecurityException,
-      FeaturestoreException, JobException {
+      FeaturestoreException, JobException, UnsupportedEncodingException {
     if (!Arrays.asList(TourProjectType.values()).contains(TourProjectType.valueOf(type.toUpperCase()))) {
       throw new IllegalArgumentException("Type must be one of: " + Arrays.toString(TourProjectType.values()));
     }

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/project/util/DsUpdateOperations.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/project/util/DsUpdateOperations.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.security.AccessControlException;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.logging.Level;
 
 /**
@@ -74,7 +75,7 @@ public class DsUpdateOperations {
    */
   public org.apache.hadoop.fs.Path createDirectoryInDataset(
       Project project, Users user, String directoryName, String description, int templateId, Boolean isSearchable)
-      throws DatasetException, ProjectException, HopsSecurityException {
+      throws DatasetException, ProjectException, HopsSecurityException, UnsupportedEncodingException {
     DsPath dsPath = pathValidator.validatePath(project, directoryName);
     org.apache.hadoop.fs.Path fullPath = dsPath.getFullPath();
 
@@ -109,7 +110,8 @@ public class DsUpdateOperations {
    * @throws ProjectException
    */
   public org.apache.hadoop.fs.Path deleteDatasetFile(
-      Project project, Users user, String fileName) throws DatasetException, ProjectException, HopsSecurityException {
+      Project project, Users user, String fileName) throws DatasetException, ProjectException, HopsSecurityException,
+      UnsupportedEncodingException {
     boolean success = false;
     DistributedFileSystemOps dfso = null;
     DsPath dsPath = pathValidator.validatePath(project, fileName);
@@ -166,7 +168,7 @@ public class DsUpdateOperations {
    * @throws ProjectException
    */
   public org.apache.hadoop.fs.Path moveDatasetFile(Project project, Users user, Inode sourceInode, String destPathStr)
-      throws DatasetException, ProjectException, HopsSecurityException {
+      throws DatasetException, ProjectException, HopsSecurityException, UnsupportedEncodingException {
     String username = hdfsUsersBean.getHdfsUserName(project, user);
     String sourcePathStr = inodeController.getPath(sourceInode);
     DsPath sourceDsPath = pathValidator.validatePath(project, sourcePathStr);

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/project/util/PathValidator.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/project/util/PathValidator.java
@@ -58,10 +58,9 @@ import org.apache.hadoop.fs.Path;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import java.io.File;
+import java.io.UnsupportedEncodingException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Stateless
 public class PathValidator {
@@ -91,21 +90,16 @@ public class PathValidator {
    * file/directory) starting from the dataset path
    */
 
-  public DsPath validatePath(Project project, String path) throws DatasetException, ProjectException {
+  public DsPath validatePath(Project project, String path) throws DatasetException, ProjectException,
+      UnsupportedEncodingException {
     DsPath dsPath = new DsPath();
-
-    Pattern authorityPattern = Pattern.compile("(hdfs://[a-zA-Z0-9\\-\\.]{2,255}:[0-9]{4,6})(/.*$)");
-    Matcher urlMatcher = authorityPattern.matcher(path);
-
     if (path == null || path.isEmpty()) {
       throw new IllegalArgumentException("path was not provided.");
-    } else if (urlMatcher.find()) {
-      // Case hdfs://10.0.2.15:8020//Projects/project1/ds/dsRelativePath
-      path = urlMatcher.group(2);
-      dsPath.setFullPath(new Path(path));
-      String[] pathComponents = path.split("/");
-      buildProjectDsRelativePath(project, pathComponents, dsPath);
-    } else if (path.startsWith(File.separator + Settings.DIR_ROOT)) {
+    } 
+    
+    path = Utils.prepPath(path);
+    
+    if (path.startsWith(File.separator + Settings.DIR_ROOT)) {
       // Case /Projects/project1/ds/dsRelativePath
       dsPath.setFullPath(new Path(path));
       String[] pathComponents = path.split("/");

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/python/environment/EnvironmentResource.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/python/environment/EnvironmentResource.java
@@ -36,6 +36,7 @@ import io.hops.hopsworks.jwt.annotation.JWTRequired;
 import io.hops.hopsworks.restutils.RESTCodes;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import java.io.UnsupportedEncodingException;
 
 import javax.ejb.EJB;
 import javax.ejb.TransactionAttribute;
@@ -167,7 +168,7 @@ public class EnvironmentResource {
   @AllowedProjectRoles({AllowedProjectRoles.DATA_SCIENTIST, AllowedProjectRoles.DATA_OWNER})
   @JWTRequired(acceptedTokens = {Audience.API}, allowedUserRoles = {"HOPS_ADMIN", "HOPS_USER"})
   public Response postYml(EnvironmentYmlDTO environmentYmlDTO, @Context UriInfo uriInfo, @Context SecurityContext sc)
-    throws PythonException, ServiceException, DatasetException, ProjectException {
+    throws PythonException, ServiceException, DatasetException, ProjectException, UnsupportedEncodingException {
     Users user = jWTHelper.getUserPrincipal(sc);
     String allYmlPath = getYmlPath(environmentYmlDTO.getAllYmlPath());
     String cpuYmlPath = getYmlPath(environmentYmlDTO.getCpuYmlPath());
@@ -190,7 +191,7 @@ public class EnvironmentResource {
     return Response.noContent().build();
   }
 
-  private String getYmlPath(String path) throws DatasetException, ProjectException {
+  private String getYmlPath(String path) throws DatasetException, ProjectException, UnsupportedEncodingException {
     if(Strings.isNullOrEmpty(path)) {
       return null;
     }

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/serving/ServingService.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/serving/ServingService.java
@@ -37,6 +37,7 @@ import io.hops.hopsworks.restutils.RESTCodes;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import java.io.UnsupportedEncodingException;
 
 import javax.ejb.EJB;
 import javax.ejb.TransactionAttribute;
@@ -175,7 +176,7 @@ public class ServingService {
       @ApiParam(value = "serving specification", required = true)
         ServingView serving)
       throws ServingException, ServiceException, KafkaException, ProjectException, UserException,
-        InterruptedException, ExecutionException {
+        InterruptedException, ExecutionException, UnsupportedEncodingException {
     Users user = jWTHelper.getUserPrincipal(sc);
     if (serving == null) {
       throw new IllegalArgumentException("serving was not provided");

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/serving/ServingUtil.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/serving/ServingUtil.java
@@ -31,6 +31,7 @@ import io.hops.hopsworks.restutils.RESTCodes;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import java.io.FileNotFoundException;
+import java.io.UnsupportedEncodingException;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.logging.Level;
@@ -56,8 +57,10 @@ public class ServingUtil {
    * @param servingWrapper contains the user-data to validate
    * @param project the project where the serving resides
    * @throws ServingException
+   * @throws java.io.UnsupportedEncodingException
    */
-  public void validateUserInput(ServingWrapper servingWrapper, Project project) throws ServingException {
+  public void validateUserInput(ServingWrapper servingWrapper, Project project) throws ServingException,
+      UnsupportedEncodingException {
     // Check that the modelName is present
     if (Strings.isNullOrEmpty(servingWrapper.getServing().getName())) {
       throw new IllegalArgumentException("Serving name not provided");
@@ -95,9 +98,11 @@ public class ServingUtil {
    * @param servingWrapper the user data
    * @param project the project to create the serving for
    * @throws ServingException if the python environment is not activated for the project
+   * @throws java.io.UnsupportedEncodingException
    */
-  public void validateSKLearnUserInput(ServingWrapper servingWrapper, Project project) throws ServingException {
-    
+  public void validateSKLearnUserInput(ServingWrapper servingWrapper, Project project) throws ServingException,
+      UnsupportedEncodingException {
+  
     // Check that the script name is valid and exists
     String scriptName = Utils.getFileName(servingWrapper.getServing().getArtifactPath());
     if(!scriptName.contains(".py")){
@@ -105,9 +110,7 @@ public class ServingUtil {
     }
     String hdfsPath = servingWrapper.getServing().getArtifactPath();
     //Remove hdfs:// if it is in the path
-    if (hdfsPath.substring(0, 7).equalsIgnoreCase("hdfs://")) {
-      hdfsPath = hdfsPath.substring(7);
-    }
+    hdfsPath = Utils.prepPath(hdfsPath);
     if(!inodeController.existsPath(hdfsPath)){
       throw new IllegalArgumentException("Python script path does not exist in HDFS");
     }

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/tensorflow/TensorBoardService.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/tensorflow/TensorBoardService.java
@@ -37,6 +37,7 @@ import io.hops.hopsworks.exceptions.ServiceException;
 import io.hops.hopsworks.common.experiments.TensorBoardController;
 import io.hops.hopsworks.jwt.annotation.JWTRequired;
 import io.swagger.annotations.ApiOperation;
+import java.io.UnsupportedEncodingException;
 
 import javax.ejb.EJB;
 import javax.ejb.TransactionAttribute;
@@ -121,7 +122,7 @@ public class TensorBoardService {
   @AllowedProjectRoles({AllowedProjectRoles.DATA_OWNER, AllowedProjectRoles.DATA_SCIENTIST})
   @JWTRequired(acceptedTokens={Audience.API}, allowedUserRoles={"HOPS_ADMIN", "HOPS_USER"})
   public Response startTensorBoard(@PathParam("elasticId") String elasticId, @Context SecurityContext sc) throws
-      ServiceException, DatasetException, ProjectException, TensorBoardException {
+      ServiceException, DatasetException, ProjectException, TensorBoardException, UnsupportedEncodingException {
 
     Users user = jWTHelper.getUserPrincipal(sc);
 

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/hdfs/DistributedFileSystemOps.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/hdfs/DistributedFileSystemOps.java
@@ -170,7 +170,14 @@ public class DistributedFileSystemOps {
     return cat(path);
   }
 
-  public void copyFromHDFSToLocal(String src, String dest) throws IOException {
+  /**
+   * Copy from HDFS to the local file system.
+   * <p/>
+   * @param hdfsPath
+   * @param localPath
+   * @throws IOException
+   */
+  public void copyToLocal(String src, String dest) throws IOException {
     dfs.copyToLocalFile(new Path(src), new Path(dest));
   }
 
@@ -282,23 +289,6 @@ public class DistributedFileSystemOps {
   }
 
   /**
-   * Copy from HDFS to the local file system.
-   * <p/>
-   * @param hdfsPath
-   * @param localPath
-   * @throws IOException
-   */
-  public void copyToLocal(String hdfsPath, String localPath) throws IOException {
-    if (!hdfsPath.startsWith("hdfs:")) {
-      hdfsPath = "hdfs://" + hdfsPath;
-    }
-    if (!localPath.startsWith("file:")) {
-      localPath = "file://" + localPath;
-    }
-    dfs.copyToLocalFile(new Path(hdfsPath), new Path(localPath));
-  }
-
-  /**
    * Copy a file from the local path to the HDFS destination.
    * <p/>
    * @param deleteSource If true, deletes the source file after copying.
@@ -345,26 +335,12 @@ public class DistributedFileSystemOps {
     if (source.equals(destination)) {
       return;
     }
-    //If source does not start with hdfs, prepend.
-    if (!source.startsWith("hdfs")) {
-      source = "hdfs://" + source;
-    }
-
-    //Check destination place, create directory.
-    String destDir;
-    if (!destination.startsWith("hdfs")) {
-      destDir = Utils.getDirectoryPart(destination);
-      destination = "hdfs://" + destination;
-    } else {
-      String tmp = destination.substring("hdfs://".length());
-      destDir = Utils.getDirectoryPart(tmp);
-    }
-    Path dest = new Path(destDir);
-    if (!dfs.exists(dest)) {
-      dfs.mkdirs(dest);
-    }
     Path src = new Path(source);
     Path dst = new Path(destination);
+    
+    if (!dfs.exists(dst.getParent())) {
+      dfs.mkdirs(dst.getParent());
+    }
     moveWithinHdfs(src, dst);
   }
 

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/hdfs/Utils.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/hdfs/Utils.java
@@ -45,10 +45,14 @@ import io.hops.hopsworks.common.util.Settings;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.StringReader;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 import java.util.logging.Logger;
 import javax.json.Json;
 import javax.json.stream.JsonParsingException;
+import org.apache.hadoop.fs.Path;
 
 public final class Utils {
 
@@ -144,5 +148,30 @@ public final class Utils {
 
     //fetch the whole file content at once
     return scanner.useDelimiter("\\Z").next();
+  }
+  
+  /**
+   * take a String corresponding to a file uri and return only the path part of the it.
+   * And transform shared path into there full path.
+   * @param path the string from which to extract the path
+   * @return the path
+   * @throws UnsupportedEncodingException 
+   */
+  public static String prepPath(String path) throws UnsupportedEncodingException {
+    Path p;
+    String result = path;
+    if (path.contains(Settings.SHARED_FILE_SEPARATOR)) {
+      String[] parts = path.split(Settings.SHARED_FILE_SEPARATOR);
+      p = new Path(parts[0]);
+      //remove hdfs://10.0.2.15:8020//
+      p = new Path(URLDecoder.decode(p.toUri().getRawPath(), StandardCharsets.UTF_8.toString()));
+      result = p.toString() + Settings.SHARED_FILE_SEPARATOR + parts[1];
+    } else {
+      p = new Path(path);
+      //remove hdfs://10.0.2.15:8020//
+      p = new Path(URLDecoder.decode(p.toUri().getRawPath(), StandardCharsets.UTF_8.toString()));
+      result = p.toString();
+    }
+    return result;
   }
 }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/execution/ExecutionController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/execution/ExecutionController.java
@@ -59,6 +59,7 @@ import io.hops.hopsworks.common.dao.user.activity.ActivityFlag;
 import io.hops.hopsworks.common.hdfs.DistributedFileSystemOps;
 import io.hops.hopsworks.common.hdfs.DistributedFsService;
 import io.hops.hopsworks.common.hdfs.HdfsUsersController;
+import io.hops.hopsworks.common.hdfs.Utils;
 import io.hops.hopsworks.common.jobs.AppInfoDTO;
 import io.hops.hopsworks.common.jobs.AsynchronousJobExecutor;
 import io.hops.hopsworks.common.jobs.JobLogDTO;
@@ -93,6 +94,7 @@ import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -101,7 +103,6 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -144,7 +145,7 @@ public class ExecutionController {
   
   @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
   public Execution start(Jobs job, Users user) throws JobException, GenericException, ServiceException,
-    ProjectException {
+    ProjectException, UnsupportedEncodingException {
     //A job can only have one execution running
     List<Execution> jobExecs = execFacade.findByJob(job);
     if(!jobExecs.isEmpty()) {
@@ -177,10 +178,7 @@ public class ExecutionController {
         }
         SparkJobConfiguration config = (SparkJobConfiguration) job.getJobConfig();
         String path = config.getAppPath();
-        String patternString = REMOTE_PROTOCOL + "(.*)\\s";
-        Pattern.compile(patternString).matcher(path);
-        String[] parts = path.split("/");
-        String pathOfInode = path.replace(REMOTE_PROTOCOL + parts[2], "");
+        String pathOfInode = Utils.prepPath(path);
         Inode inode = inodeController.getInodeAtPath(pathOfInode);
         String inodeName = inode.getInodePK().getName();
 

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/flink/FlinkController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/flink/FlinkController.java
@@ -50,6 +50,7 @@ import io.hops.hopsworks.common.dao.user.activity.ActivityFacade;
 import io.hops.hopsworks.common.dao.user.activity.ActivityFlag;
 import io.hops.hopsworks.common.hdfs.HdfsUsersController;
 import io.hops.hopsworks.common.hdfs.UserGroupInformationService;
+import io.hops.hopsworks.common.hdfs.Utils;
 import io.hops.hopsworks.common.hdfs.inode.InodeController;
 import io.hops.hopsworks.common.jobs.AsynchronousJobExecutor;
 import io.hops.hopsworks.common.jobs.configuration.JobType;
@@ -252,7 +253,7 @@ public class FlinkController {
     Yaml yaml = new Yaml();
     try (InputStream in = new FileInputStream(new File(settings.getFlinkConfFile()))) {
       Map<String, Object> obj = (Map<String, Object>) yaml.load(in);
-      return ((String) obj.get("historyserver.archive.fs.dir")).replace("hdfs://", "");
+      return Utils.prepPath((String) obj.get("historyserver.archive.fs.dir"));
     }
   }
   

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/spark/SparkYarnRunnerBuilder.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/spark/SparkYarnRunnerBuilder.java
@@ -154,8 +154,7 @@ public class SparkYarnRunnerBuilder {
     builder.addLocalResource(new LocalResourceDTO(
         appExecName, appPath,
         LocalResourceVisibility.APPLICATION.toString(),
-        LocalResourceType.FILE.toString(), null),
-        !appPath.startsWith("hdfs:"));
+        LocalResourceType.FILE.toString(), null), dfsClient);
 
     builder.addToAppMasterEnvironment(YarnRunner.KEY_CLASSPATH,
         Settings.SPARK_LOCRSC_APP_JAR
@@ -261,7 +260,7 @@ public class SparkYarnRunnerBuilder {
         builder.addLocalResource(new LocalResourceDTO(
                 fileName, filePath,
                 LocalResourceVisibility.APPLICATION.toString(),
-                LocalResourceType.FILE.toString(), null), false);
+                LocalResourceType.FILE.toString(), null), dfsClient);
       }
     }
 
@@ -276,7 +275,7 @@ public class SparkYarnRunnerBuilder {
         builder.addLocalResource(new LocalResourceDTO(
           fileName, archivePath,
           LocalResourceVisibility.APPLICATION.toString(),
-          LocalResourceType.ARCHIVE.toString(), null), false);
+          LocalResourceType.ARCHIVE.toString(), null), dfsClient);
       }
     }
 

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/yarn/YarnExecutionFinalizer.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/yarn/YarnExecutionFinalizer.java
@@ -176,7 +176,10 @@ public class YarnExecutionFinalizer {
     DistributedFileSystemOps dfso = dfs.getDfsOps();
     try {
       for (String s : filesToRemove) {
-        if (s.startsWith("hdfs:") && dfso.getFilesystem().exists(new Path(s))) {
+        Path path = new Path(s);
+        String scheme = path.toUri().getScheme();
+        if (scheme != null && (scheme.equals(dfso.getFilesystem().getScheme()) || scheme.equals(dfso.getFilesystem().
+            getAlternativeScheme())) && dfso.getFilesystem().exists(path))  {
           dfso.getFilesystem().delete(new Path(s), true);
         } else {
           org.apache.commons.io.FileUtils.deleteQuietly(new File(s));

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/project/ProjectController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/project/ProjectController.java
@@ -157,6 +157,7 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSession;
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -2316,7 +2317,7 @@ public class ProjectController {
   public void addTourFilesToProject(String username, Project project,
     DistributedFileSystemOps dfso, DistributedFileSystemOps udfso,
     TourProjectType projectType) throws DatasetException, HopsSecurityException, ProjectException,
-    JobException, GenericException, ServiceException {
+    JobException, GenericException, ServiceException, UnsupportedEncodingException {
 
     Users user = userFacade.findByEmail(username);
     if (null != projectType) {

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/CertificateMaterializer.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/CertificateMaterializer.java
@@ -91,8 +91,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static io.hops.hopsworks.common.util.Settings.CERT_PASS_SUFFIX;
 import static io.hops.hopsworks.common.util.Settings.KEYSTORE_SUFFIX;
@@ -104,7 +102,6 @@ import static io.hops.hopsworks.common.util.Settings.TRUSTSTORE_SUFFIX;
 public class CertificateMaterializer {
   private static final Logger LOG = Logger.getLogger(CertificateMaterializer.class.getName());
   
-  private final static Pattern HDFS_SCHEME = Pattern.compile("^hdfs://.*");
   private final static int MAX_NUMBER_OF_RETRIES = 3;
   private final static long RETRY_WAIT_TIMEOUT = 10;
   
@@ -1130,11 +1127,11 @@ public class CertificateMaterializer {
   }
   
   private String normalizeURI(String uri) {
-    Matcher uriMatcher = HDFS_SCHEME.matcher(uri);
-    if (!uriMatcher.matches()) {
-      uri = "hdfs://" + uri;
+    Path path = new Path(uri);
+    if(path.toUri().getScheme()==null){
+      path.setScheme("hopsfs");
     }
-    return uri;
+    return path.toString();
   }
 
   /**

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/IoUtils.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/IoUtils.java
@@ -44,12 +44,8 @@ import com.google.common.io.Files;
 import com.google.common.io.Resources;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
 import java.util.List;
-import java.util.jar.JarFile;
-import java.util.jar.Manifest;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class IoUtils {
@@ -86,37 +82,4 @@ public class IoUtils {
     URL fileUrl = new URL(url);
     return Resources.toString(fileUrl, Charsets.UTF_8);
   }
-
-  public static String getMainClassNameFromJar(String amJarPath,
-          InputStream inputStream) {
-    if (amJarPath == null) {
-      throw new IllegalStateException(
-              "amJar path cannot be null.");
-    }
-    String fileName = amJarPath;
-
-    if (amJarPath.startsWith("hdfs:")) {
-      // download the jar file
-    }
-
-    String mainClassName = null;
-
-    try (JarFile jarFile = new JarFile(fileName)) {
-      Manifest manifest = jarFile.getManifest();
-      if (manifest != null) {
-        mainClassName = manifest.getMainAttributes().getValue("Main-Class");
-      }
-    } catch (IOException io) {
-      logger.log(Level.SEVERE, "Could not open jar file " + amJarPath
-              + " to load main class.", io);
-      return null;
-    }
-
-    if (mainClassName != null) {
-      return mainClassName.replaceAll("/", ".");
-    } else {
-      return null;
-    }
-  }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 
   <properties>
     <java.version>1.8</java.version>
-    <hops.version>2.8.2.8</hops.version>
+    <hops.version>2.8.2.9-SNAPSHOT</hops.version>
     <dependency.plugin.version>2.8</dependency.plugin.version>
     <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1425

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the new behavior (if this is a feature change)?**
hopsfs changed to use hopsfs as default scheme. Hopsworks need to be able to handle this scheme and not expect only hdfs for scheme.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
Depends on hops-2.8.2.9-SNAPSHOT.
For this to work with chef the following pull request need to be merged:
logicalclocks/hive-chef#37
logicalclocks/spark-chef#84
logicalclocks/hops-hadoop-chef#171
logicalclocks/hops-util-py#138
logicalclocks/hive#5